### PR TITLE
Fix int overflow when parsing cpuacct cgroup file

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -39,7 +39,7 @@ func cpuacctUsage(container string) (int64, error) {
 	}
 	defer f.Close()
 
-	buffer := make([]byte, 16)
+	buffer := make([]byte, 64)
 	n, err := f.Read(buffer)
 	buffer = buffer[:n]
 


### PR DESCRIPTION
the value of the file is a big integer -> number of nanoseconds of CPU used since started.. so int64

Fixes #7