### PR TITLE
fix(docker-compose): remove port bidings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,8 @@ services:
       CGROUP_DIR: /host/cgroup
       PROC_DIR: /host/proc
       DOCKER_URL: unix:///host/docker.sock
+      PORT: 4244
     command: reflex -r '\.go$$' -s -- sh -c 'go build ./cmd/acadock-monitoring && ./acadock-monitoring'
     privileged: true
     pid: host
     network_mode: host
-    ports:
-      - "4244:4244"
-


### PR DESCRIPTION
When the network_mode is set to host, the container will use the host's networking interfaces, making your port bindings useless as the container will have access to the host's ports.

A recent Docker Compose upgrade probably changed the behaviour to return in error in this case whereas it silently ignored the port bindings in previous versions.

With this modification, it is still possible to query the service from the local machine, which indicates it does not impact the availability of the service:

```
curl -vvvv http://localhost:4244/host/usage
*   Trying 127.0.0.1:4244...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 4244 (#0)
> GET /host/usage HTTP/1.1
> Host: localhost:4244
> User-Agent: curl/7.68.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 401 Unauthorized
< Content-Type: application/json
< Date: Tue, 21 Sep 2021 16:19:53 GMT
< Content-Length: 0
<
* Connection #0 to host localhost left intact