### PR TITLE
fix(SRE-840) Wrap all errors and replace errgo by errors on agent and client side

### DIFF
--- a/cmd/acadock-monitoring/main.go
+++ b/cmd/acadock-monitoring/main.go
@@ -81,11 +81,11 @@ func main() {
 	r.Use(handlers.ErrorMiddleware)
 
 	r.HandleFunc("/containers/{id}/mem", controller.ContainerMemUsageHandler).Methods("GET")
-	r.HandleFunc("/containers/{id}/cpu", controller.ContainerCpuUsageHandler).Methods("GET")
+	r.HandleFunc("/containers/{id}/cpu", controller.ContainerCPUUsageHandler).Methods("GET")
 	r.HandleFunc("/containers/{id}/net", controller.ContainerNetUsageHandler).Methods("GET")
 	r.HandleFunc("/containers/{id}/usage", controller.ContainerUsageHandler).Methods("GET")
 	r.HandleFunc("/containers/usage", controller.ContainersUsageHandler).Methods("GET")
-	r.HandleFunc("/host/usage", controller.HostResources)
+	r.HandleFunc("/host/usage", controller.HostResourcesHandler).Methods("GET")
 
 	if *doProfile {
 		pprofRouter := mux.NewRouter()

--- a/docker/client.go
+++ b/docker/client.go
@@ -3,9 +3,10 @@ package docker
 import (
 	"sync"
 
-	"github.com/Scalingo/acadock-monitoring/config"
 	"github.com/fsouza/go-dockerclient"
-	"gopkg.in/errgo.v1"
+	"github.com/pkg/errors"
+
+	"github.com/Scalingo/acadock-monitoring/config"
 )
 
 var (
@@ -15,12 +16,13 @@ var (
 
 func Client() (*docker.Client, error) {
 	var err error
+
 	_clientOnce.Do(func() {
 		_client, err = docker.NewClient(config.ENV["DOCKER_URL"])
 	})
-
 	if err != nil {
-		return nil, errgo.Mask(err)
+		return nil, errors.Wrap(err, "fail to create docker client")
 	}
+
 	return _client, nil
 }

--- a/docker/list.go
+++ b/docker/list.go
@@ -2,18 +2,18 @@ package docker
 
 import (
 	"github.com/fsouza/go-dockerclient"
-	"gopkg.in/errgo.v1"
+	"github.com/pkg/errors"
 )
 
 func ListContainers() ([]docker.APIContainers, error) {
 	client, err := Client()
 	if err != nil {
-		return nil, errgo.Mask(err)
+		return nil, errors.Wrap(err, "fail to get docker client")
 	}
 
 	containers, err := client.ListContainers(docker.ListContainersOptions{})
 	if err != nil {
-		return nil, errgo.Mask(err)
+		return nil, errors.Wrap(err, "fail to list docker containers")
 	}
 
 	return containers, nil

--- a/docker/listen.go
+++ b/docker/listen.go
@@ -2,19 +2,19 @@ package docker
 
 import (
 	"github.com/fsouza/go-dockerclient"
-	"gopkg.in/errgo.v1"
+	"github.com/pkg/errors"
 )
 
 func ListenNewContainers(ids chan string) error {
 	client, err := Client()
 	if err != nil {
-		return errgo.Mask(err)
+		return errors.Wrap(err, "fail to get docker client")
 	}
 
 	listener := make(chan *docker.APIEvents)
 	err = client.AddEventListener(listener)
 	if err != nil {
-		return errgo.Mask(err)
+		return errors.Wrap(err, "fail to add event listener")
 	}
 
 	for event := range listener {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/tklauser/go-sysconf v0.3.10
 	github.com/urfave/negroni v1.0.0
-	gopkg.in/errgo.v1 v1.0.1
 )
 
 require (
@@ -52,5 +51,6 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/errgo.v1 v1.0.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/net/net.go
+++ b/net/net.go
@@ -42,7 +42,7 @@ func (monitor *NetMonitor) Start() {
 		<-tick.C
 		stats, err := netstat.Stats()
 		if err != nil {
-			log.WithError(err).Warn("Fail to get network stats")
+			log.WithError(err).Info("Fail to get network stats")
 			continue
 		}
 		for _, stat := range stats {

--- a/webserver/containers.go
+++ b/webserver/containers.go
@@ -11,7 +11,8 @@ import (
 	"github.com/Scalingo/go-utils/logger"
 )
 
-func (c Controller) ContainerUsageHandler(res http.ResponseWriter, _ *http.Request, params map[string]string) error {
+func (c Controller) ContainerUsageHandler(res http.ResponseWriter, req *http.Request, params map[string]string) error {
+	log := logger.Get(req.Context())
 	id := params["id"]
 	usage := client.Usage{}
 
@@ -36,12 +37,13 @@ func (c Controller) ContainerUsageHandler(res http.ResponseWriter, _ *http.Reque
 	res.WriteHeader(200)
 	err = json.NewEncoder(res).Encode(&usage)
 	if err != nil {
-		return errors.Wrapf(err, "fail to encode container usage payload")
+		log.WithError(err).Error("Fail to encode container usage payload")
 	}
 	return nil
 }
 
-func (c Controller) ContainerMemUsageHandler(res http.ResponseWriter, _ *http.Request, params map[string]string) error {
+func (c Controller) ContainerMemUsageHandler(res http.ResponseWriter, req *http.Request, params map[string]string) error {
+	log := logger.Get(req.Context())
 	id := params["id"]
 
 	containerMemoryUsage, err := c.mem.GetMemoryUsage(id)
@@ -52,12 +54,13 @@ func (c Controller) ContainerMemUsageHandler(res http.ResponseWriter, _ *http.Re
 	res.WriteHeader(200)
 	err = json.NewEncoder(res).Encode(&containerMemoryUsage)
 	if err != nil {
-		return errors.Wrapf(err, "fail to encode container memory usage payload")
+		log.WithError(err).Error("Fail to encode container memory usage payload")
 	}
 	return nil
 }
 
-func (c Controller) ContainerCPUUsageHandler(res http.ResponseWriter, _ *http.Request, params map[string]string) error {
+func (c Controller) ContainerCPUUsageHandler(res http.ResponseWriter, req *http.Request, params map[string]string) error {
+	log := logger.Get(req.Context())
 	id := params["id"]
 
 	containerCpuUsage, err := c.cpu.GetContainerUsage(id)
@@ -68,12 +71,13 @@ func (c Controller) ContainerCPUUsageHandler(res http.ResponseWriter, _ *http.Re
 	res.WriteHeader(200)
 	err = json.NewEncoder(res).Encode(&containerCpuUsage)
 	if err != nil {
-		return errors.Wrapf(err, "fail to encode container cpu usage payload")
+		log.WithError(err).Error("Fail to encode container cpu usage payload")
 	}
 	return nil
 }
 
 func (c Controller) ContainerNetUsageHandler(res http.ResponseWriter, req *http.Request, params map[string]string) error {
+	log := logger.Get(req.Context())
 	id := params["id"]
 
 	containerNet, err := c.net.GetUsage(id)
@@ -84,24 +88,24 @@ func (c Controller) ContainerNetUsageHandler(res http.ResponseWriter, req *http.
 	res.WriteHeader(200)
 	err = json.NewEncoder(res).Encode(&containerNet)
 	if err != nil {
-		return errors.Wrapf(err, "fail to encode container network usage payload")
+		log.WithError(err).Error("Fail to encode container network usage payload")
 	}
 	return nil
 }
 
-func (c Controller) ContainersUsageHandler(res http.ResponseWriter, req *http.Request, params map[string]string) error {
+func (c Controller) ContainersUsageHandler(res http.ResponseWriter, req *http.Request, _ map[string]string) error {
 	log := logger.Get(req.Context())
 
 	usage := client.NewContainersUsage()
 	containers, err := docker.ListContainers()
 	if err != nil {
-		res.WriteHeader(500)
 		log.WithError(err).Error("Fail to list containers")
 
+		res.WriteHeader(500)
 		errs := map[string]string{"message": "fail to list containers", "error": err.Error()}
 		err := json.NewEncoder(res).Encode(&errs)
 		if err != nil {
-			return errors.Wrapf(err, "fail to encode containers usage error payload")
+			log.WithError(err).Error("Fail to encode containers usage error payload")
 		}
 		return nil
 	}
@@ -109,19 +113,19 @@ func (c Controller) ContainersUsageHandler(res http.ResponseWriter, req *http.Re
 	for _, container := range containers {
 		cpuUsage, err := c.cpu.GetContainerUsage(container.ID)
 		if err != nil {
-			log.WithError(err).Warnf("Fail to get CPU usage of '%v'", container.ID)
+			log.WithError(err).Infof("Fail to get CPU usage of '%v'", container.ID)
 			continue
 		}
 
 		memUsage, err := c.mem.GetMemoryUsage(container.ID)
 		if err != nil {
-			log.WithError(err).Warnf("Fail to get Memory usage of '%v'", container.ID)
+			log.WithError(err).Infof("Fail to get Memory usage of '%v'", container.ID)
 			continue
 		}
 
 		netUsage, err := c.net.GetUsage(container.ID)
 		if err != nil {
-			log.WithError(err).Warnf("Fail to get Network usage of '%v'", container.ID)
+			log.WithError(err).Infof("Fail to get Network usage of '%v'", container.ID)
 			continue
 		}
 
@@ -133,9 +137,10 @@ func (c Controller) ContainersUsageHandler(res http.ResponseWriter, req *http.Re
 		}
 	}
 
+	res.WriteHeader(200)
 	err = json.NewEncoder(res).Encode(&usage)
 	if err != nil {
-		return errors.Wrapf(err, "fail to encode containers usage payload")
+		log.WithError(err).Error("Fail to encode containers usage payload")
 	}
 	return nil
 }

--- a/webserver/containers.go
+++ b/webserver/containers.go
@@ -4,104 +4,127 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/Scalingo/acadock-monitoring/docker"
+	"github.com/pkg/errors"
 
 	"github.com/Scalingo/acadock-monitoring/client"
+	"github.com/Scalingo/acadock-monitoring/docker"
 	"github.com/Scalingo/go-utils/logger"
-	"github.com/gorilla/mux"
 )
 
-func (c Controller) ContainerUsageHandler(res http.ResponseWriter, req *http.Request, params map[string]string) error {
+func (c Controller) ContainerUsageHandler(res http.ResponseWriter, _ *http.Request, params map[string]string) error {
 	id := params["id"]
 	usage := client.Usage{}
 
 	memUsage, err := c.mem.GetMemoryUsage(id)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "fail to get container memory usage")
 	}
 	usage.Memory = &memUsage.MemoryUsage
 
 	cpuUsage, err := c.cpu.GetContainerUsage(id)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "fail to get container cpu usage")
 	}
 	usage.Cpu = (*client.CpuUsage)(&cpuUsage)
 
 	netUsage, err := c.net.GetUsage(id)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "fail to get container network usage")
 	}
 	usage.Net = (*client.NetUsage)(&netUsage)
 
 	res.WriteHeader(200)
-	json.NewEncoder(res).Encode(&usage)
+	err = json.NewEncoder(res).Encode(&usage)
+	if err != nil {
+		return errors.Wrapf(err, "fail to encode container usage payload")
+	}
 	return nil
 }
 
-func (c Controller) ContainerMemUsageHandler(res http.ResponseWriter, req *http.Request, params map[string]string) error {
-	id := mux.Vars(req)["id"]
+func (c Controller) ContainerMemUsageHandler(res http.ResponseWriter, _ *http.Request, params map[string]string) error {
+	id := params["id"]
 
 	containerMemoryUsage, err := c.mem.GetMemoryUsage(id)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "fail to get container memory usage")
 	}
 
 	res.WriteHeader(200)
-	json.NewEncoder(res).Encode(&containerMemoryUsage)
+	err = json.NewEncoder(res).Encode(&containerMemoryUsage)
+	if err != nil {
+		return errors.Wrapf(err, "fail to encode container memory usage payload")
+	}
 	return nil
 }
 
-func (c Controller) ContainerCpuUsageHandler(res http.ResponseWriter, req *http.Request, params map[string]string) error {
+func (c Controller) ContainerCPUUsageHandler(res http.ResponseWriter, _ *http.Request, params map[string]string) error {
 	id := params["id"]
 
 	containerCpuUsage, err := c.cpu.GetContainerUsage(id)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "fail to get container cpu usage")
 	}
+
 	res.WriteHeader(200)
-	json.NewEncoder(res).Encode(&containerCpuUsage)
+	err = json.NewEncoder(res).Encode(&containerCpuUsage)
+	if err != nil {
+		return errors.Wrapf(err, "fail to encode container cpu usage payload")
+	}
 	return nil
 }
 
 func (c Controller) ContainerNetUsageHandler(res http.ResponseWriter, req *http.Request, params map[string]string) error {
 	id := params["id"]
+
 	containerNet, err := c.net.GetUsage(id)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "fail to get container network usage")
 	}
 
 	res.WriteHeader(200)
-	json.NewEncoder(res).Encode(&containerNet)
+	err = json.NewEncoder(res).Encode(&containerNet)
+	if err != nil {
+		return errors.Wrapf(err, "fail to encode container network usage payload")
+	}
 	return nil
 }
 
 func (c Controller) ContainersUsageHandler(res http.ResponseWriter, req *http.Request, params map[string]string) error {
 	log := logger.Get(req.Context())
+
 	usage := client.NewContainersUsage()
 	containers, err := docker.ListContainers()
 	if err != nil {
 		res.WriteHeader(500)
 		log.WithError(err).Error("Fail to list containers")
-		errors := map[string]string{"message": "fail to list containers", "error": err.Error()}
-		json.NewEncoder(res).Encode(&errors)
+
+		errs := map[string]string{"message": "fail to list containers", "error": err.Error()}
+		err := json.NewEncoder(res).Encode(&errs)
+		if err != nil {
+			return errors.Wrapf(err, "fail to encode containers usage error payload")
+		}
 		return nil
 	}
+
 	for _, container := range containers {
 		cpuUsage, err := c.cpu.GetContainerUsage(container.ID)
 		if err != nil {
-			log.WithError(err).Errorf("Fail to get CPU usage of '%v'", container.ID)
+			log.WithError(err).Warnf("Fail to get CPU usage of '%v'", container.ID)
 			continue
 		}
+
 		memUsage, err := c.mem.GetMemoryUsage(container.ID)
 		if err != nil {
-			log.WithError(err).Errorf("Fail to get Memory usage of '%v'", container.ID)
+			log.WithError(err).Warnf("Fail to get Memory usage of '%v'", container.ID)
 			continue
 		}
+
 		netUsage, err := c.net.GetUsage(container.ID)
 		if err != nil {
-			log.WithError(err).Errorf("Fail to get Network usage of '%v'", container.ID)
+			log.WithError(err).Warnf("Fail to get Network usage of '%v'", container.ID)
 			continue
 		}
+
 		usage[container.ID] = client.Usage{
 			Cpu:    (*client.CpuUsage)(&cpuUsage),
 			Memory: &memUsage.MemoryUsage,
@@ -109,6 +132,10 @@ func (c Controller) ContainersUsageHandler(res http.ResponseWriter, req *http.Re
 			Labels: container.Labels,
 		}
 	}
-	json.NewEncoder(res).Encode(&usage)
+
+	err = json.NewEncoder(res).Encode(&usage)
+	if err != nil {
+		return errors.Wrapf(err, "fail to encode containers usage payload")
+	}
 	return nil
 }

--- a/webserver/host.go
+++ b/webserver/host.go
@@ -55,7 +55,7 @@ func (c Controller) HostResourcesHandler(res http.ResponseWriter, req *http.Requ
 
 		usage, err := c.mem.GetMemoryUsage(container.ID)
 		if err != nil {
-			log.WithError(err).Warnf("Fail to get memory usage for %s", container.ID)
+			log.WithError(err).Infof("Fail to get memory usage for %s", container.ID)
 			continue
 		}
 
@@ -72,9 +72,10 @@ func (c Controller) HostResourcesHandler(res http.ResponseWriter, req *http.Requ
 		Memory: memory,
 	}
 
+	res.WriteHeader(200)
 	err = json.NewEncoder(res).Encode(&result)
 	if err != nil {
-		return errors.Wrap(err, "fail to encode host usage payload")
+		log.WithError(err).Error("Fail to encode host usage payload")
 	}
 	return nil
 }

--- a/webserver/host.go
+++ b/webserver/host.go
@@ -5,9 +5,14 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+
+	"github.com/Scalingo/acadock-monitoring/client"
+	"github.com/Scalingo/acadock-monitoring/docker"
+	"github.com/Scalingo/acadock-monitoring/filters"
+	"github.com/Scalingo/go-utils/logger"
 )
 
-func (c Controller) HostResources(res http.ResponseWriter, req *http.Request, params map[string]string) error {
+func (c Controller) HostResourcesHandler(res http.ResponseWriter, req *http.Request, _ map[string]string) error {
 	ctx := req.Context()
 	log := logger.Get(ctx)
 
@@ -67,6 +72,9 @@ func (c Controller) HostResources(res http.ResponseWriter, req *http.Request, pa
 		Memory: memory,
 	}
 
-	json.NewEncoder(res).Encode(&result)
+	err = json.NewEncoder(res).Encode(&result)
+	if err != nil {
+		return errors.Wrap(err, "fail to encode host usage payload")
+	}
 	return nil
 }


### PR DESCRIPTION
Fix [SRE-840]

This PR make improvement on multiple things:
- Wrap all errors to be able to investigate correctly on agent and client side
- Replace `errgo` by `pkg/errors` on all the project
- Don't return an error when memory can't be fetched for one container, just skip the container and return normally at the end

[SRE-840]: https://scalingo.atlassian.net/browse/SRE-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ