### PR TITLE
Bump v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## To Be Released
 
+## v2.0.0 - 2025-09-08
+
+* deps(dependabot) Various upgrades
+* improvement(net): Usage of netlink to read net metrics instead of forking into net namespace
 * feat(cgroup): Compatibility with cgroup v2: use github.com/containerd/cgroup to read cgroup data for v1 and v2
 * fix(resiliency): Make service resilient to docker restart
 * chore(go): use Go 1.24

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Acadock Monitoring - Docker container monitoring v1.2.1
+# Acadock Monitoring - Docker container monitoring v2.0.0
 
 This webservice provides live data on Docker containers. It takes
 data from the Linux kernel control groups and from the namespace of
@@ -88,7 +88,7 @@ Bump new version number in:
 Commit, tag and create a new release:
 
 ```sh
-version="1.2.1"
+version="2.0.0"
 
 git switch --create release/${version}
 git add CHANGELOG.md README.md


### PR DESCRIPTION
## v2.0.0 - 2025-09-08

* improvement(net): Usage of netlink to read net metrics instead of forking into net namespace
* feat(cgroup): Compatibility with cgroup v2: use github.com/containerd/cgroup to read cgroup data for v1 and v2
* fix(resiliency): Make service resilient to docker restart
* chore(go): use Go 1.24
* build(go.mod): update `github.com/urfave/negroni` from v1 to v3
* chore(go): use Go 1.22.10
* use github.com/Scalingo/go-utils/graceful for graceful upgrades and shutdowns
* use github.com/Scalingo/go-utils/errors/v3 for errors management
* use github.com/docker/docker instead of github.com/fsouza/go-dockerclient
