### PR TITLE
Bump v2.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+## v2.0.6 - 2026-05-12
+
 * build(deps): replace dependency `github.com/docker/docker` with `github.com/moby/moby`
 
 ## v2.0.5 - 2025-04-13

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Acadock Monitoring - Docker container monitoring v2.0.5
+# Acadock Monitoring - Docker container monitoring v2.0.6
 
 This webservice provides live data on Docker containers. It takes
 data from the Linux kernel control groups and from the namespace of
@@ -88,11 +88,11 @@ Bump new version number in:
 Commit, tag and create a new release:
 
 ```sh
-version="2.0.4"
+version="2.0.6"
 
 git switch --create release/${version}
 git add CHANGELOG.md README.md
-git commit -m "Bump v${version}"
+git commit --message="Bump v${version}"
 git push --set-upstream origin release/${version}
 gh pr create --reviewer=Scalingo/team-ist --fill-first
 ```


### PR DESCRIPTION
Include the fix for https://github.com/Scalingo/acadock-monitoring/issues/205