### PR TITLE
fix(mountinfo/namespeace) Add ability to configure from which mountinfo we're getting mount information

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ From environment
 * `CGROUP_SOURCE`: "docker" or "systemd" (docker by default)
   docker:  /sys/fs/cgroup/:cgroup/memory/docker
   systemd: /sys/fs/cgroup/:cgroup/memory/system.slice/docker-#{id}.slice
+* `PROC_DIR`: procfs mountpoint (default to /proc)
+* `PROC_MOUNTINFO_PID`: PID used to read mountinfo for IO device mountpoints (default to the acadock-monitoring PID). Set it to 1 with `PROC_DIR=/host/proc` to use the host/root mount namespace from a container.
 * `DEBUG`: output of debugging information (default "false", switch to "true" to enable)
 
 ## Docker
@@ -25,6 +27,7 @@ Run from docker:
 
 ```bash
 docker run -v /sys/fs/cgroup:/host/cgroup:ro         -e CGROUP_DIR=/host/cgroup \
+           -v /proc:/host/proc:ro -e PROC_DIR=/host/proc -e PROC_MOUNTINFO_PID=1 \
            -v /var/run/docker.sock:/host/docker.sock -e DOCKER_URL=unix:///host/docker.sock \
            -p 4244:4244 --privileged --pid=host --network=host \
            -d scalingo/acadock-monitoring

--- a/cmd/acadock-monitoring/main.go
+++ b/cmd/acadock-monitoring/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
+	"strconv"
 
 	"github.com/gorilla/mux"
 	"github.com/urfave/negroni/v3"
@@ -55,7 +56,14 @@ func main() {
 	go queueLength.Start(ctx)
 
 	containerRepository := docker.NewContainerRepository()
-	mountInfos, err := procfs.NewMountInfoReader(ctx)
+	mountInfoPID := 0
+	if config.ENV["PROC_MOUNTINFO_PID"] != "" {
+		mountInfoPID, err = strconv.Atoi(config.ENV["PROC_MOUNTINFO_PID"])
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}
+	mountInfos, err := procfs.NewMountInfoReader(ctx, config.ENV["PROC_DIR"], mountInfoPID)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/config/env.go
+++ b/config/env.go
@@ -15,6 +15,7 @@ var ENV = map[string]string{
 	"CGROUP_SOURCE":                  "docker",
 	"CGROUP_DIR":                     "/sys/fs/cgroup",
 	"PROC_DIR":                       "/proc",
+	"PROC_MOUNTINFO_PID":             "",
 	"RUNNER_DIR":                     "/usr/bin",
 	"DEBUG":                          "false",
 	"NET_MONITORING":                 "true",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - .:/go/src/github.com/Scalingo/acadock-monitoring
     env_file:
       - .env
+    environment:
+      PROC_DIR: /host/proc
+      PROC_MOUNTINFO_PID: "1"
     command: reflex -r '\.go$$' -s -- sh -c 'go build -buildvcs=false ./cmd/acadock-monitoring && ./acadock-monitoring'
     privileged: true
     pid: host

--- a/procfs/mountinfo.go
+++ b/procfs/mountinfo.go
@@ -32,16 +32,18 @@ type MountInfoReader struct {
 	devices    map[string]string
 }
 
-func NewMountInfoReader(ctx context.Context) (*MountInfoReader, error) {
-	_, err := prometheusprocfs.NewFS("/proc")
+func NewMountInfoReader(ctx context.Context, procDir string, pid int) (*MountInfoReader, error) {
+	procFS, err := prometheusprocfs.NewFS(procDir)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, "create procfs filesystem")
 	}
-	pid := os.Getpid()
+	if pid == 0 {
+		pid = os.Getpid()
+	}
 
 	return &MountInfoReader{
 		getMountInfos: func() ([]*prometheusprocfs.MountInfo, error) {
-			return prometheusprocfs.GetProcMounts(pid)
+			return procFS.GetProcMounts(pid)
 		},
 		sysDevBlock: "/sys/dev/block",
 		dev:         "/dev",


### PR DESCRIPTION
Fixes #218 so we can access the root namespace instead of docker compose container

Result (Before is in the issue):

```
  "io": {
    "devices": [
      {
        "device_path": "/dev/nvme0n1",
        "major": 259,
        "minor": 0,
        "read_bytes": 438272,
        "read_ios": 18,
        "write_bytes": 0,
        "write_ios": 0
      },
      {
        "device_path": "/dev/dm-0",
        "major": 252,
        "minor": 0,
        "read_bytes": 438272,
        "read_ios": 18,
        "write_bytes": 0,
        "write_ios": 0
      },
      {
        "device_path": "/dev/dm-1",
        "major": 252,
        "minor": 1,
        "mountpoint": "/",
        "read_bytes": 438272,
        "read_ios": 18,
        "write_bytes": 8192,
        "write_ios": 2
      }
    ]
  },
```